### PR TITLE
Remove workaround with class level event

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -20,21 +20,4 @@ class Events
     {
         Yii::$app->notification->setSpaceSetting($event->user, $event->space, true);
     }
-
-    /*
-     * Callback on class level event of ActiveRecord
-     *
-     * Switch on the space notifications for creator of the space
-     *
-     * @param AfterSaveEvent $event
-     */
-    public static function onSpaceEvent($event)
-    {
-        $current = $event->sender;
-
-        // Check if a space was created
-        if($current::class == \humhub\modules\space\models\Membership::class && $current->user_id !== null && $current->user_id === $current->created_by) {
-	    Yii::$app->notification->setSpaceSetting($current->user, $current->space, true);
-        }
-    }
 }

--- a/Events.php
+++ b/Events.php
@@ -9,10 +9,9 @@ class Events
 {
     /*
      * Callback on user joining a space
-
-     Callback on user joining a space
      *
      * Switch on the space notifications when a user is added to a space (after invitation, request or direct adding)
+     * since HumHub v1.13.1 the event is also called for the space creator
      *
      * @param MemberEvent $event
     */

--- a/config.php
+++ b/config.php
@@ -14,11 +14,6 @@ return [
             'class' => Membership::class,
             'event' => Membership::EVENT_MEMBER_ADDED,
             'callback' => [Events::class, 'onSpaceMemberAdded']
-        ],
-        [
-            'class' => ActiveRecord::class,
-            'event' => ActiveRecord::EVENT_AFTER_INSERT,
-            'callback' => [Events::class, 'onSpaceEvent']
         ]
     ]
 ];

--- a/config.php
+++ b/config.php
@@ -1,7 +1,6 @@
 <?php
 
 use yii\base\Event;
-use yii\db\ActiveRecord;
 use humhub\modules\followallspacecontent\Events;
 use humhub\modules\space\models\Membership;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1 (unreleased)
+- Enh: Remove workaround with class level event (not needed anymore since HumHub 1.13.1)
+
 ## 0.2.0 (11 december 2022)
 - Enh: Now it also works for the space creator.
 

--- a/module.json
+++ b/module.json
@@ -5,9 +5,9 @@
     "keywords": [
 	"notifications"
     ],
-    "version": "0.2.0",
+    "version": "0.2.1",
      "humhub": {
-        "minVersion": "1.9"
+        "minVersion": "1.13.1"
     },
     "homepage": "https://hahn-felix.de",
     "authors": [


### PR DESCRIPTION
Since HumHub v1.13.1 (not yet released) the EVENT_MEMBER_ADDED event is also called for the space creator, see [fix #6051](https://github.com/humhub/humhub/pull/6053).

So the workaround with the class level event becomes unnecessary.

